### PR TITLE
[BE] 소셜 로그인 기능 추가 #TSK-55

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 group = 'com.jungko'
 version = '0.0.1-SNAPSHOT'
 
-java.sourceCompatibility = '17'
+java.sourceCompatibility = '11'
 
 bootRun {
     environment SPRING_PROFILES_ACTIVE: environment.SPRING_PROFILES_ACTIVE ?: 'local'
@@ -34,6 +34,7 @@ dependencies {
     implementation('org.springframework.boot:spring-boot-starter-data-jpa')
     implementation('org.springframework.boot:spring-boot-starter-security')
     implementation('org.springframework.boot:spring-boot-starter-oauth2-resource-server')
+    implementation('org.springframework.boot:spring-boot-starter-oauth2-client')
 
 //  Monitoring
     implementation('org.springframework.boot:spring-boot-starter-actuator')

--- a/src/main/java/com/jungko/jungko_server/auth/annotation/LoginMemberInfo.java
+++ b/src/main/java/com/jungko/jungko_server/auth/annotation/LoginMemberInfo.java
@@ -1,0 +1,16 @@
+package com.jungko.jungko_server.auth.annotation;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal
+@Parameter(hidden = true)
+public @interface LoginMemberInfo {
+
+}

--- a/src/main/java/com/jungko/jungko_server/auth/controller/AuthController.java
+++ b/src/main/java/com/jungko/jungko_server/auth/controller/AuthController.java
@@ -1,9 +1,13 @@
 package com.jungko.jungko_server.auth.controller;
 
+import com.jungko.jungko_server.auth.annotation.LoginMemberInfo;
+import com.jungko.jungko_server.auth.domain.MemberRole;
+import com.jungko.jungko_server.auth.dto.MemberSessionDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -20,13 +24,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "인증", description = "인증 관련 API")
 public class AuthController {
 
-  @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 요청합니다. 회원과 관련된 모든 정보(작성한 카드, 관심 카드, 관심 키워드, 회원 정보 등)가 삭제되며, 소셜 인증 기관에 revoke 요청을 수행합니다.")
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "204", description = "no content"),
-  })
-  @ResponseStatus(HttpStatus.NO_CONTENT)
-  @DeleteMapping(value = "/unregister")
-  public void unregister() {
-    log.info("Called unregister");
-  }
+	@Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 요청합니다. 회원과 관련된 모든 정보(작성한 카드, 관심 카드, 관심 키워드, 회원 정보 등)가 삭제되며, 소셜 인증 기관에 revoke 요청을 수행합니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "204", description = "no content"),
+	})
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@DeleteMapping(value = "/unregister")
+	@Secured(MemberRole.S_USER)
+	public void unregister(@LoginMemberInfo MemberSessionDto memberSessionDto) {
+		log.info("Called unregister member: {}", memberSessionDto);
+	}
 }

--- a/src/main/java/com/jungko/jungko_server/auth/domain/CookieManager.java
+++ b/src/main/java/com/jungko/jungko_server/auth/domain/CookieManager.java
@@ -10,10 +10,19 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 @Slf4j
+/*
+  쿠키 관리를 담당하는 클래스
+ */
 public class CookieManager {
 
 	private final CookieConfig cookieConfig;
 
+	/**
+	 * 쿠키를 생성하여 HttpServletResponse 객체에 추가한다.
+	 *
+	 * @param res   클라이언트에게 보낼 응답을 나타내는 HttpServletResponse 객체
+	 * @param token 쿠키에 저장될 토큰 값
+	 */
 	public void createCookie(HttpServletResponse res, String token) {
 		log.info("Called setCookie path");
 		Cookie cookie = new Cookie(cookieConfig.getName(), token);

--- a/src/main/java/com/jungko/jungko_server/auth/domain/CookieManager.java
+++ b/src/main/java/com/jungko/jungko_server/auth/domain/CookieManager.java
@@ -1,0 +1,26 @@
+package com.jungko.jungko_server.auth.domain;
+
+import com.jungko.jungko_server.config.CookieConfig;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CookieManager {
+
+	private final CookieConfig cookieConfig;
+
+	public void createCookie(HttpServletResponse res, String token) {
+		log.info("Called setCookie path");
+		Cookie cookie = new Cookie(cookieConfig.getName(), token);
+		cookie.setPath(cookieConfig.getPath());
+		cookie.setMaxAge(cookieConfig.getMaxAge());
+		cookie.setHttpOnly(cookieConfig.isHttpOnly());
+		cookie.setDomain(cookieConfig.getDomain());
+		res.addCookie(cookie);
+	}
+}

--- a/src/main/java/com/jungko/jungko_server/auth/domain/MemberRole.java
+++ b/src/main/java/com/jungko/jungko_server/auth/domain/MemberRole.java
@@ -1,0 +1,5 @@
+package com.jungko.jungko_server.auth.domain;
+
+public enum MemberRole {
+	COMMON, ADMIN
+}

--- a/src/main/java/com/jungko/jungko_server/auth/domain/MemberRole.java
+++ b/src/main/java/com/jungko/jungko_server/auth/domain/MemberRole.java
@@ -1,5 +1,7 @@
 package com.jungko.jungko_server.auth.domain;
 
 public enum MemberRole {
-	COMMON, ADMIN
+	ADMIN, USER;
+	public static final String S_ADMIN = "ROLE_ADMIN";
+	public static final String S_USER = "ROLE_USER";
 }

--- a/src/main/java/com/jungko/jungko_server/auth/domain/Oauth2Type.java
+++ b/src/main/java/com/jungko/jungko_server/auth/domain/Oauth2Type.java
@@ -1,0 +1,12 @@
+package com.jungko.jungko_server.auth.domain;
+
+public enum Oauth2Type {
+	GOOGLE,
+	NAVER,
+	KAKAO,
+	;
+
+	public static Oauth2Type of(String name) {
+		return Oauth2Type.valueOf(name.toUpperCase());
+	}
+}

--- a/src/main/java/com/jungko/jungko_server/auth/dto/MemberSessionDto.java
+++ b/src/main/java/com/jungko/jungko_server/auth/dto/MemberSessionDto.java
@@ -1,0 +1,18 @@
+package com.jungko.jungko_server.auth.dto;
+
+import com.jungko.jungko_server.auth.domain.MemberRole;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@ToString
+public class MemberSessionDto {
+
+	private final Long memberId;
+	private final List<MemberRole> roles;
+}

--- a/src/main/java/com/jungko/jungko_server/auth/dto/MemberSessionDto.java
+++ b/src/main/java/com/jungko/jungko_server/auth/dto/MemberSessionDto.java
@@ -11,6 +11,9 @@ import lombok.ToString;
 @AllArgsConstructor
 @Builder
 @ToString
+/*
+  로그인한 회원의 정보를 담는 클래스
+ */
 public class MemberSessionDto {
 
 	private final Long memberId;

--- a/src/main/java/com/jungko/jungko_server/auth/jwt/JwtAuthenticationConfig.java
+++ b/src/main/java/com/jungko/jungko_server/auth/jwt/JwtAuthenticationConfig.java
@@ -17,24 +17,36 @@ import org.springframework.security.oauth2.server.resource.InvalidBearerTokenExc
 @Configuration
 @RequiredArgsConstructor
 public class JwtAuthenticationConfig {
+
 	private final JwtDecoder jwtDecoder;
 	private final JwtAuthenticationConverter jwtAuthenticationConverter;
 
 	@Bean
+	/*
+	  JwtAuthenticationManager를 Bean으로 등록한다.
+	  JwtAuthenticationProvider를 이용하여 인증을 수행한다.
+	 */
 	public AuthenticationManager jwtAuthenticationManager() {
 		return (Authentication authentication) -> {
 			AuthenticationProvider authenticationProvider = jwtAuthenticationProvider();
-			if (authenticationProvider.supports(authentication.getClass()))
+			if (authenticationProvider.supports(authentication.getClass())) {
 				return authenticationProvider.authenticate(authentication);
-			throw new AuthenticationServiceException("Unsupported authentication type: " + authentication.getClass().getName());
+			}
+			throw new AuthenticationServiceException(
+					"Unsupported authentication type: " + authentication.getClass().getName());
 		};
 	}
 
 	@Bean
+	/*
+	  JwtAuthenticationProvider를 Bean으로 등록한다.
+	  BearerTokenAuthenticationToken을 Jwt로 변환한다.
+	 */
 	public AuthenticationProvider jwtAuthenticationProvider() {
 		return new AuthenticationProvider() {
 			@Override
-			public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+			public Authentication authenticate(Authentication authentication)
+					throws AuthenticationException {
 				BearerTokenAuthenticationToken token = (BearerTokenAuthenticationToken) authentication;
 				Jwt jwt = getJwt(token);
 				return jwtAuthenticationConverter.convert(jwt);

--- a/src/main/java/com/jungko/jungko_server/auth/jwt/JwtAuthenticationConfig.java
+++ b/src/main/java/com/jungko/jungko_server/auth/jwt/JwtAuthenticationConfig.java
@@ -1,0 +1,59 @@
+package com.jungko.jungko_server.auth.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken;
+import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
+
+@Configuration
+@RequiredArgsConstructor
+public class JwtAuthenticationConfig {
+	private final JwtDecoder jwtDecoder;
+	private final JwtAuthenticationConverter jwtAuthenticationConverter;
+
+	@Bean
+	public AuthenticationManager jwtAuthenticationManager() {
+		return (Authentication authentication) -> {
+			AuthenticationProvider authenticationProvider = jwtAuthenticationProvider();
+			if (authenticationProvider.supports(authentication.getClass()))
+				return authenticationProvider.authenticate(authentication);
+			throw new AuthenticationServiceException("Unsupported authentication type: " + authentication.getClass().getName());
+		};
+	}
+
+	@Bean
+	public AuthenticationProvider jwtAuthenticationProvider() {
+		return new AuthenticationProvider() {
+			@Override
+			public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+				BearerTokenAuthenticationToken token = (BearerTokenAuthenticationToken) authentication;
+				Jwt jwt = getJwt(token);
+				return jwtAuthenticationConverter.convert(jwt);
+			}
+
+			@Override
+			public boolean supports(Class<?> authentication) {
+				return authentication.equals(BearerTokenAuthenticationToken.class);
+			}
+
+			private Jwt getJwt(BearerTokenAuthenticationToken token) {
+				try {
+					return jwtDecoder.decode(token.getToken());
+				} catch (JwtException e) {
+					throw new InvalidBearerTokenException("jwt 관련 오류", e);
+				} catch (RuntimeException e) {
+					throw new InvalidBearerTokenException("jwt 파싱 관련 오류", e);
+				}
+			}
+		};
+	}
+}

--- a/src/main/java/com/jungko/jungko_server/auth/jwt/JwtAuthenticationConverter.java
+++ b/src/main/java/com/jungko/jungko_server/auth/jwt/JwtAuthenticationConverter.java
@@ -19,6 +19,11 @@ public class JwtAuthenticationConverter implements Converter<Jwt, JwtAuthenticat
 	private static final String SCOPE_PREFIX = "SCOPE_";
 
 	@Override
+	/*
+	  Jwt를 JwtAuthenticationToken으로 변환한다.
+	  @param jwt 변환할 Jwt
+	 * @return JwtAuthenticationToken 변환된 JwtAuthenticationToken
+	 */
 	public JwtAuthenticationToken convert(Jwt jwt) {
 		List<GrantedAuthority> authorities = new ArrayList<>();
 		if (jwt.hasClaim(JwtConfig.ROLES)) {

--- a/src/main/java/com/jungko/jungko_server/auth/jwt/JwtAuthenticationConverter.java
+++ b/src/main/java/com/jungko/jungko_server/auth/jwt/JwtAuthenticationConverter.java
@@ -17,22 +17,21 @@ public class JwtAuthenticationConverter implements Converter<Jwt, JwtAuthenticat
 
 	private static final String ROLE_PREFIX = "ROLE_";
 	private static final String SCOPE_PREFIX = "SCOPE_";
-	private final JwtConfig jwtConfig;
 
 	@Override
 	public JwtAuthenticationToken convert(Jwt jwt) {
 		List<GrantedAuthority> authorities = new ArrayList<>();
-		if (jwt.hasClaim(jwtConfig.getRolesKey())) {
+		if (jwt.hasClaim(JwtConfig.ROLES)) {
 			authorities.addAll(
-					jwt.getClaimAsStringList(jwtConfig.getRolesKey())
+					jwt.getClaimAsStringList(JwtConfig.ROLES)
 							.stream()
 							.map(role -> ROLE_PREFIX + role)
 							.map(SimpleGrantedAuthority::new)
 							.collect(Collectors.toList())
 			);
 		}
-		if (jwt.hasClaim(jwtConfig.getScopesKey())) {
-			authorities.addAll(jwt.getClaimAsStringList(jwtConfig.getScopesKey()).stream()
+		if (jwt.hasClaim(JwtConfig.SCOPES)) {
+			authorities.addAll(jwt.getClaimAsStringList(JwtConfig.SCOPES).stream()
 					.map(scope -> SCOPE_PREFIX + scope)
 					.map(SimpleGrantedAuthority::new)
 					.collect(Collectors.toList())

--- a/src/main/java/com/jungko/jungko_server/auth/jwt/JwtAuthenticationConverter.java
+++ b/src/main/java/com/jungko/jungko_server/auth/jwt/JwtAuthenticationConverter.java
@@ -1,0 +1,43 @@
+package com.jungko.jungko_server.auth.jwt;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationConverter implements Converter<Jwt, JwtAuthenticationToken> {
+
+	private static final String ROLE_PREFIX = "ROLE_";
+	private static final String SCOPE_PREFIX = "SCOPE_";
+	private final JwtConfig jwtConfig;
+
+	@Override
+	public JwtAuthenticationToken convert(Jwt jwt) {
+		List<GrantedAuthority> authorities = new ArrayList<>();
+		if (jwt.hasClaim(jwtConfig.getRolesKey())) {
+			authorities.addAll(
+					jwt.getClaimAsStringList(jwtConfig.getRolesKey())
+							.stream()
+							.map(role -> ROLE_PREFIX + role)
+							.map(SimpleGrantedAuthority::new)
+							.collect(Collectors.toList())
+			);
+		}
+		if (jwt.hasClaim(jwtConfig.getScopesKey())) {
+			authorities.addAll(jwt.getClaimAsStringList(jwtConfig.getScopesKey()).stream()
+					.map(scope -> SCOPE_PREFIX + scope)
+					.map(SimpleGrantedAuthority::new)
+					.collect(Collectors.toList())
+			);
+		}
+		return new JwtAuthenticationToken(jwt, authorities, jwt.getSubject());
+	}
+}

--- a/src/main/java/com/jungko/jungko_server/auth/jwt/JwtCodecConfig.java
+++ b/src/main/java/com/jungko/jungko_server/auth/jwt/JwtCodecConfig.java
@@ -1,0 +1,38 @@
+package com.jungko.jungko_server.auth.jwt;
+
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+
+@Configuration
+public class JwtCodecConfig {
+
+	private final static MacAlgorithm algorithm = MacAlgorithm.HS256;
+	private final SecretKey key;
+	public JwtCodecConfig(
+			@Value("${spring.jwt.key}") String secretKey
+	) {
+		this.key = new SecretKeySpec(secretKey.getBytes(), algorithm.getName());
+	}
+
+	@Bean
+	public JwtDecoder jwtDecoder() {
+		return NimbusJwtDecoder
+				.withSecretKey(key)
+				.macAlgorithm(algorithm)
+				.build();
+	}
+
+	@Bean
+	public JwtEncoder jwtEncoder() {
+		return new NimbusJwtEncoder(new ImmutableSecret<>(key));
+	}
+}

--- a/src/main/java/com/jungko/jungko_server/auth/jwt/JwtCodecConfig.java
+++ b/src/main/java/com/jungko/jungko_server/auth/jwt/JwtCodecConfig.java
@@ -13,10 +13,14 @@ import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
 
 @Configuration
+/*
+  JWT 인코더/디코더를 위한 설정 클래스
+ */
 public class JwtCodecConfig {
 
 	private final static MacAlgorithm algorithm = MacAlgorithm.HS256;
 	private final SecretKey key;
+
 	public JwtCodecConfig(
 			@Value("${spring.jwt.key}") String secretKey
 	) {

--- a/src/main/java/com/jungko/jungko_server/auth/jwt/JwtConfig.java
+++ b/src/main/java/com/jungko/jungko_server/auth/jwt/JwtConfig.java
@@ -8,14 +8,9 @@ import org.springframework.context.annotation.Configuration;
 @Getter
 public class JwtConfig {
 
-	@Value("${jungko.jwt.roles-key}")
-	private String rolesKey;
-
-	@Value("${jungko.jwt.scopes-key}")
-	private String scopesKey;
-
-	@Value("${jungko.jwt.user-id-key}")
-	private String userIdKey;
+	public static final String ROLES = "roles";
+	public static final String SCOPES = "scopes";
+	public static final String USERID = "userId";
 
 	@Value("${jungko.jwt.common-token-expire-time}")
 	private long commonTokenExpireTime;

--- a/src/main/java/com/jungko/jungko_server/auth/jwt/JwtConfig.java
+++ b/src/main/java/com/jungko/jungko_server/auth/jwt/JwtConfig.java
@@ -1,0 +1,25 @@
+package com.jungko.jungko_server.auth.jwt;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+public class JwtConfig {
+
+	@Value("${jungko.jwt.roles-key}")
+	private String rolesKey;
+
+	@Value("${jungko.jwt.scopes-key}")
+	private String scopesKey;
+
+	@Value("${jungko.jwt.user-id-key}")
+	private String userIdKey;
+
+	@Value("${jungko.jwt.common-token-expire-time}")
+	private long commonTokenExpireTime;
+
+	@Value("${jungko.jwt.refresh-token-expire-time}")
+	private long refreshTokenExpireTime;
+}

--- a/src/main/java/com/jungko/jungko_server/auth/jwt/JwtExceptionHandler.java
+++ b/src/main/java/com/jungko/jungko_server/auth/jwt/JwtExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.jungko.jungko_server.auth.jwt;
+
+import com.jungko.jungko_server.util.AuthResponseMessages;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Configuration
+public class JwtExceptionHandler {
+	@Bean
+	public AuthenticationEntryPoint jwtAuthenticationEntryPoint() {
+		return (HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) -> {
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, AuthResponseMessages.JWT_AUTH_FAILURE);
+		};
+	}
+
+	@Bean
+	public AccessDeniedHandler jwtAccessDeniedHandler() {
+		return (HttpServletRequest request, HttpServletResponse response, org.springframework.security.access.AccessDeniedException accessDeniedException) -> {
+			response.sendError(HttpServletResponse.SC_FORBIDDEN, AuthResponseMessages.JWT_ACCESS_FAILURE);
+		};
+	}
+}

--- a/src/main/java/com/jungko/jungko_server/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/jungko/jungko_server/auth/jwt/JwtTokenProvider.java
@@ -14,11 +14,20 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+/*
+  JWT 토큰 생성을 위한 클래스
+ */
 public class JwtTokenProvider {
 
 	private final JwtEncoder jwtEncoder;
 	private final JwtConfig jwtConfig;
 
+	/**
+	 * 주어진 ID를 가진 회원의 Common Access JWT Token을 생성한다.
+	 *
+	 * @param id 회원의 ID
+	 * @return 생성된 JWT Token
+	 */
 	public Jwt createCommonAccessToken(Long id) {
 		Instant now = Instant.now();
 		JwsHeader header = JwsHeader

--- a/src/main/java/com/jungko/jungko_server/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/jungko/jungko_server/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,36 @@
+package com.jungko.jungko_server.auth.jwt;
+
+import com.jungko.jungko_server.auth.domain.MemberRole;
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+	private final JwtEncoder jwtEncoder;
+	private final JwtConfig jwtConfig;
+
+	public Jwt createCommonAccessToken(Long id) {
+		Instant now = Instant.now();
+		JwsHeader header = JwsHeader
+				.with(MacAlgorithm.HS256)
+				.build();
+
+		JwtClaimsSet claims = JwtClaimsSet.builder()
+				.issuedAt(now)
+				.expiresAt(now.plusSeconds(jwtConfig.getCommonTokenExpireTime()))
+				.claim(jwtConfig.getUserIdKey(), id)
+				.claim(jwtConfig.getRolesKey(), List.of(MemberRole.COMMON.name()))
+				.build();
+		return jwtEncoder.encode(JwtEncoderParameters.from(header, claims));
+	}
+}

--- a/src/main/java/com/jungko/jungko_server/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/jungko/jungko_server/auth/jwt/JwtTokenProvider.java
@@ -28,8 +28,8 @@ public class JwtTokenProvider {
 		JwtClaimsSet claims = JwtClaimsSet.builder()
 				.issuedAt(now)
 				.expiresAt(now.plusSeconds(jwtConfig.getCommonTokenExpireTime()))
-				.claim(jwtConfig.getUserIdKey(), id)
-				.claim(jwtConfig.getRolesKey(), List.of(MemberRole.COMMON.name()))
+				.claim(JwtConfig.USERID, id)
+				.claim(JwtConfig.ROLES, List.of(MemberRole.S_USER))
 				.build();
 		return jwtEncoder.encode(JwtEncoderParameters.from(header, claims));
 	}

--- a/src/main/java/com/jungko/jungko_server/auth/jwt/MemberSessionAuthenticationFilter.java
+++ b/src/main/java/com/jungko/jungko_server/auth/jwt/MemberSessionAuthenticationFilter.java
@@ -22,6 +22,9 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Transient
 @Slf4j
 @RequiredArgsConstructor
+/*
+  JWT 토큰을 이용한 인증을 위한 커스텀 인증 필터
+ */
 public class MemberSessionAuthenticationFilter extends OncePerRequestFilter {
 
 	@Override
@@ -49,6 +52,12 @@ public class MemberSessionAuthenticationFilter extends OncePerRequestFilter {
 		doFilter(request, response, filterChain);
 	}
 
+	/**
+	 * JwtAuthenticationToken을 우리 시스템의 커스텀 MemberSessionAuthenticationToken으로 변환한다.
+	 *
+	 * @param token JwtAuthenticationToken 인증 토큰
+	 * @return 변환된 커스텀 인증 토큰
+	 */
 	private MemberSessionAuthenticationToken convert(JwtAuthenticationToken token) {
 		Object target = token.getPrincipal();
 		if (target instanceof Jwt) {
@@ -64,6 +73,12 @@ public class MemberSessionAuthenticationFilter extends OncePerRequestFilter {
 		throw new JwtAuthenticationTokenException("JwtAuthenticationToken의 Principal이 Jwt가 아닙니다.");
 	}
 
+	/**
+	 * Jwt Principal 정보를 토대로 회원 인증 정보 DTO 객체를 생성한다.
+	 *
+	 * @param jwt Jwt Principal 정보
+	 * @return 회원 인증 정보 DTO 객체
+	 */
 	private MemberSessionDto convertPrincipal(Jwt jwt) {
 		Long memberId = jwt.getClaim(JwtConfig.USERID);
 		List<MemberRole> roles = jwt.getClaim(JwtConfig.ROLES);

--- a/src/main/java/com/jungko/jungko_server/auth/jwt/MemberSessionAuthenticationFilter.java
+++ b/src/main/java/com/jungko/jungko_server/auth/jwt/MemberSessionAuthenticationFilter.java
@@ -1,0 +1,79 @@
+package com.jungko.jungko_server.auth.jwt;
+
+import com.jungko.jungko_server.auth.domain.MemberRole;
+import com.jungko.jungko_server.auth.dto.MemberSessionDto;
+import com.jungko.jungko_server.util.JwtAuthenticationTokenException;
+import java.io.IOException;
+import java.util.List;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.Transient;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Transient
+@Slf4j
+@RequiredArgsConstructor
+public class MemberSessionAuthenticationFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request,
+			HttpServletResponse response, FilterChain filterChain)
+			throws ServletException, IOException {
+		SecurityContext context = SecurityContextHolder.getContext();
+		Authentication authentication = context.getAuthentication();
+		if (authentication == null) {
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "로그인이 필요합니다.");
+			return;
+		}
+		try {
+			if (authentication instanceof JwtAuthenticationToken) {
+				JwtAuthenticationToken jwtAuthenticationToken = (JwtAuthenticationToken) authentication;
+				MemberSessionAuthenticationToken token = convert(jwtAuthenticationToken);
+				context.setAuthentication(token);
+				SecurityContextHolder.clearContext();
+				SecurityContextHolder.setContext(context);
+			}
+		} catch (JwtAuthenticationTokenException e) {
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, e.getMessage());
+			return;
+		}
+		doFilter(request, response, filterChain);
+	}
+
+	private MemberSessionAuthenticationToken convert(JwtAuthenticationToken token) {
+		Object target = token.getPrincipal();
+		if (target instanceof Jwt) {
+			Jwt jwt = (Jwt) target;
+			MemberSessionDto principal = convertPrincipal(jwt);
+			MemberSessionAuthenticationToken ret = new MemberSessionAuthenticationToken(principal,
+					token.getAuthorities());
+			ret.setAuthenticated(true);
+			log.info("convert token principal: {}, authorities: {}", ret.getPrincipal(),
+					token.getAuthorities());
+			return ret;
+		}
+		throw new JwtAuthenticationTokenException("JwtAuthenticationToken의 Principal이 Jwt가 아닙니다.");
+	}
+
+	private MemberSessionDto convertPrincipal(Jwt jwt) {
+		Long memberId = jwt.getClaim(JwtConfig.USERID);
+		List<MemberRole> roles = jwt.getClaim(JwtConfig.ROLES);
+		log.debug("memberId: {}, roles: {}", memberId, roles);
+		if (memberId == null || roles == null) {
+			throw new JwtAuthenticationTokenException("Jwt에 필요한 정보가 없습니다.");
+		}
+		return MemberSessionDto.builder()
+				.memberId(memberId)
+				.roles(roles)
+				.build();
+	}
+}

--- a/src/main/java/com/jungko/jungko_server/auth/jwt/MemberSessionAuthenticationToken.java
+++ b/src/main/java/com/jungko/jungko_server/auth/jwt/MemberSessionAuthenticationToken.java
@@ -1,0 +1,28 @@
+package com.jungko.jungko_server.auth.jwt;
+
+import java.util.Collection;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+public class MemberSessionAuthenticationToken extends AbstractAuthenticationToken {
+
+	private final Object principal;
+
+	public MemberSessionAuthenticationToken(
+			Object principal,
+			Collection<? extends GrantedAuthority> authorities
+	) {
+		super(authorities);
+		this.principal = principal;
+	}
+
+	@Override
+	public Object getCredentials() {
+		return principal;
+	}
+
+	@Override
+	public Object getPrincipal() {
+		return principal;
+	}
+}

--- a/src/main/java/com/jungko/jungko_server/auth/oauth2/Oauth2Handler.java
+++ b/src/main/java/com/jungko/jungko_server/auth/oauth2/Oauth2Handler.java
@@ -21,6 +21,9 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 @Configuration
 @RequiredArgsConstructor
 @Slf4j
+/*
+  Oauth2 인증에 대한 핸들러를 정의하는 클래스
+ */
 public class Oauth2Handler {
 
 	private final MemberRepository memberRepository;
@@ -29,6 +32,12 @@ public class Oauth2Handler {
 	private final ClientConfig clientConfig;
 
 	@Bean
+	/*
+	  Oauth2 인증 성공 시 호출되는 핸들러
+	  인증 정보를 우리 시스템에 맞도록 변환한다.
+	  변환된 인증 정보를 Member 엔티티로 영속화하고, 회원의 ID를 이용해 JWT 토큰을 생성한다.
+	  생성된 JWT 토큰을 쿠키에 담아 클라이언트로 전송한다.
+	 */
 	public AuthenticationSuccessHandler oauth2AuthenticationSuccessHandler() {
 		return (request, response, authentication) -> {
 			DefaultOAuth2User auth2User = (DefaultOAuth2User) authentication.getPrincipal();

--- a/src/main/java/com/jungko/jungko_server/auth/oauth2/Oauth2Handler.java
+++ b/src/main/java/com/jungko/jungko_server/auth/oauth2/Oauth2Handler.java
@@ -1,0 +1,69 @@
+package com.jungko.jungko_server.auth.oauth2;
+
+import com.jungko.jungko_server.auth.domain.CookieManager;
+import com.jungko.jungko_server.auth.jwt.JwtTokenProvider;
+import com.jungko.jungko_server.auth.oauth2.extractor.Oauth2AttributeExtractor;
+import com.jungko.jungko_server.config.ClientConfig;
+import com.jungko.jungko_server.member.domain.Member;
+import com.jungko.jungko_server.member.infrastructure.MemberRepository;
+import com.jungko.jungko_server.util.AuthResponseMessages;
+import java.time.LocalDateTime;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+@Configuration
+@RequiredArgsConstructor
+public class Oauth2Handler {
+
+	private final MemberRepository memberRepository;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final CookieManager cookieManager;
+	private final ClientConfig clientConfig;
+
+	@Bean
+	public AuthenticationSuccessHandler oauth2AuthenticationSuccessHandler() {
+		return (request, response, authentication) -> {
+			DefaultOAuth2User auth2User = (DefaultOAuth2User) authentication.getPrincipal();
+			OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) authentication;
+			String providerName = token.getAuthorizedClientRegistrationId();
+			Oauth2AttributeExtractor extractor = Oauth2AttributeExtractor.create(
+					auth2User, providerName
+			);
+			Member member = memberRepository.findByEmail(extractor.getEmail())
+					.orElseGet(() ->
+							memberRepository.save(
+									Member.createMember(
+											extractor.getEmail(),
+											extractor.getProfileImageUrl(),
+											extractor.getNickname(),
+											false,
+											extractor.getOauthType(),
+											extractor.getOauthId(),
+											LocalDateTime.now()
+									)
+							)
+					);
+			String jwtToken = jwtTokenProvider.createCommonAccessToken(member.getId())
+					.getTokenValue();
+			cookieManager.createCookie(
+					response, jwtToken
+			);
+			response.sendRedirect(
+					clientConfig.getClientUrl() + clientConfig.getClientCallbackUrl());
+		};
+	}
+
+	@Bean
+	public AuthenticationFailureHandler oauth2AuthenticationFailureHandler() {
+		return (request, response, exception) -> {
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			response.getWriter().println(AuthResponseMessages.OAUTH2_FAILURE);
+		};
+	}
+}

--- a/src/main/java/com/jungko/jungko_server/auth/oauth2/Oauth2Handler.java
+++ b/src/main/java/com/jungko/jungko_server/auth/oauth2/Oauth2Handler.java
@@ -10,6 +10,7 @@ import com.jungko.jungko_server.util.AuthResponseMessages;
 import java.time.LocalDateTime;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
@@ -19,6 +20,7 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 
 @Configuration
 @RequiredArgsConstructor
+@Slf4j
 public class Oauth2Handler {
 
 	private final MemberRepository memberRepository;
@@ -49,6 +51,7 @@ public class Oauth2Handler {
 									)
 							)
 					);
+			log.info("Member Login Success: {}", member);
 			String jwtToken = jwtTokenProvider.createCommonAccessToken(member.getId())
 					.getTokenValue();
 			cookieManager.createCookie(

--- a/src/main/java/com/jungko/jungko_server/auth/oauth2/extractor/GoogleOauth2AttributeExtractor.java
+++ b/src/main/java/com/jungko/jungko_server/auth/oauth2/extractor/GoogleOauth2AttributeExtractor.java
@@ -1,0 +1,40 @@
+package com.jungko.jungko_server.auth.oauth2.extractor;
+
+import com.jungko.jungko_server.auth.domain.Oauth2Type;
+import lombok.ToString;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@ToString
+public class GoogleOauth2AttributeExtractor implements Oauth2AttributeExtractor {
+
+	private final OAuth2User auth2User;
+
+	public GoogleOauth2AttributeExtractor(OAuth2User auth2User) {
+		this.auth2User = auth2User;
+	}
+
+	@Override
+	public String getEmail() {
+		return auth2User.getAttribute("email");
+	}
+
+	@Override
+	public String getNickname() {
+		return auth2User.getAttribute("name");
+	}
+
+	@Override
+	public String getProfileImageUrl() {
+		return auth2User.getAttribute("picture");
+	}
+
+	@Override
+	public Oauth2Type getOauthType() {
+		return Oauth2Type.GOOGLE;
+	}
+
+	@Override
+	public String getOauthId() {
+		return auth2User.getAttribute("sub");
+	}
+}

--- a/src/main/java/com/jungko/jungko_server/auth/oauth2/extractor/KakaoOauth2AttributeExtractor.java
+++ b/src/main/java/com/jungko/jungko_server/auth/oauth2/extractor/KakaoOauth2AttributeExtractor.java
@@ -1,0 +1,43 @@
+package com.jungko.jungko_server.auth.oauth2.extractor;
+
+import com.jungko.jungko_server.auth.domain.Oauth2Type;
+import java.util.Objects;
+import lombok.ToString;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@ToString
+public class KakaoOauth2AttributeExtractor implements Oauth2AttributeExtractor {
+
+	private final OAuth2User auth2User;
+
+	public KakaoOauth2AttributeExtractor(OAuth2User auth2User) {
+		this.auth2User = auth2User;
+	}
+
+	@Override
+	public String getEmail() {
+		return Oauth2AttributeExtractor.getNestedAttribute(auth2User, "kakao_account",
+				"email");
+	}
+
+	@Override
+	public String getNickname() {
+		return Oauth2AttributeExtractor.getNestedAttribute(auth2User, "properties", "nickname");
+	}
+
+	@Override
+	public String getProfileImageUrl() {
+		return Oauth2AttributeExtractor.getNestedAttribute(auth2User, "properties",
+				"profile_image");
+	}
+
+	@Override
+	public Oauth2Type getOauthType() {
+		return Oauth2Type.KAKAO;
+	}
+
+	@Override
+	public String getOauthId() {
+		return Objects.requireNonNull(auth2User.getAttribute("id")).toString();
+	}
+}

--- a/src/main/java/com/jungko/jungko_server/auth/oauth2/extractor/NaverOauth2AttributeExtractor.java
+++ b/src/main/java/com/jungko/jungko_server/auth/oauth2/extractor/NaverOauth2AttributeExtractor.java
@@ -5,36 +5,36 @@ import lombok.ToString;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 @ToString
-public class GoogleOauth2AttributeExtractor implements Oauth2AttributeExtractor {
+public class NaverOauth2AttributeExtractor implements Oauth2AttributeExtractor {
 
 	private final OAuth2User auth2User;
 
-	public GoogleOauth2AttributeExtractor(OAuth2User auth2User) {
+	public NaverOauth2AttributeExtractor(OAuth2User auth2User) {
 		this.auth2User = auth2User;
 	}
 
 	@Override
 	public String getEmail() {
-		return Oauth2AttributeExtractor.getNestedAttribute(auth2User, "email");
+		return Oauth2AttributeExtractor.getNestedAttribute(auth2User, "response", "email");
 	}
 
 	@Override
 	public String getNickname() {
-		return Oauth2AttributeExtractor.getNestedAttribute(auth2User, "name");
+		return Oauth2AttributeExtractor.getNestedAttribute(auth2User, "response", "nickname");
 	}
 
 	@Override
 	public String getProfileImageUrl() {
-		return Oauth2AttributeExtractor.getNestedAttribute(auth2User, "picture");
+		return Oauth2AttributeExtractor.getNestedAttribute(auth2User, "response", "profile_image");
 	}
 
 	@Override
 	public Oauth2Type getOauthType() {
-		return Oauth2Type.GOOGLE;
+		return Oauth2Type.NAVER;
 	}
 
 	@Override
 	public String getOauthId() {
-		return Oauth2AttributeExtractor.getNestedAttribute(auth2User, "sub");
+		return Oauth2AttributeExtractor.getNestedAttribute(auth2User, "response", "id");
 	}
 }

--- a/src/main/java/com/jungko/jungko_server/auth/oauth2/extractor/Oauth2AttributeExtractor.java
+++ b/src/main/java/com/jungko/jungko_server/auth/oauth2/extractor/Oauth2AttributeExtractor.java
@@ -4,6 +4,12 @@ import com.jungko.jungko_server.auth.domain.Oauth2Type;
 import java.util.Map;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
+/**
+ * // @formatter:off
+ * Oauth2User로부터 속성을 추출하는 메서드를 정의하는 인터페이스 Oauth 유저 정보를 추출하여 우리 시스템에 맞도록 변환하는 역할을 한다.
+ * 소셜 인증 기관이 추가되면이 인터페이스를 구현하여 Oauth2User로부터 속성을 추출하는 메서드를 정의해야 한다.
+ * // @formatter:on
+ */
 public interface Oauth2AttributeExtractor {
 
 	String getEmail();

--- a/src/main/java/com/jungko/jungko_server/auth/oauth2/extractor/Oauth2AttributeExtractor.java
+++ b/src/main/java/com/jungko/jungko_server/auth/oauth2/extractor/Oauth2AttributeExtractor.java
@@ -1,0 +1,30 @@
+package com.jungko.jungko_server.auth.oauth2.extractor;
+
+import com.jungko.jungko_server.auth.domain.Oauth2Type;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+public interface Oauth2AttributeExtractor {
+
+	String getEmail();
+
+	String getNickname();
+
+	String getProfileImageUrl();
+
+	Oauth2Type getOauthType();
+
+	String getOauthId();
+
+	static Oauth2AttributeExtractor create(OAuth2User auth2User, String providerName) {
+		switch (providerName) {
+			case "google":
+				return new GoogleOauth2AttributeExtractor(auth2User);
+			case "kakao":
+				return new KakaoOauth2AttributeExtractor(auth2User);
+			case "naver":
+				return new NaverOauth2AttributeExtractor(auth2User);
+			default:
+				throw new IllegalArgumentException("지원하지 않는 소셜 로그인입니다.");
+		}
+	}
+}

--- a/src/main/java/com/jungko/jungko_server/auth/oauth2/extractor/Oauth2AttributeExtractor.java
+++ b/src/main/java/com/jungko/jungko_server/auth/oauth2/extractor/Oauth2AttributeExtractor.java
@@ -1,6 +1,7 @@
 package com.jungko.jungko_server.auth.oauth2.extractor;
 
 import com.jungko.jungko_server.auth.domain.Oauth2Type;
+import java.util.Map;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 public interface Oauth2AttributeExtractor {
@@ -26,5 +27,16 @@ public interface Oauth2AttributeExtractor {
 			default:
 				throw new IllegalArgumentException("지원하지 않는 소셜 로그인입니다.");
 		}
+	}
+
+	static String getNestedAttribute(OAuth2User user, String... keys) {
+		Object value = user.getAttributes();
+		for (String key : keys) {
+			if (!(value instanceof Map)) {
+				return null;
+			}
+			value = ((Map<?, ?>) value).get(key);
+		}
+		return value instanceof String ? (String) value : null;
 	}
 }

--- a/src/main/java/com/jungko/jungko_server/auth/oauth2/extractor/Oauth2AttributeHelper.java
+++ b/src/main/java/com/jungko/jungko_server/auth/oauth2/extractor/Oauth2AttributeHelper.java
@@ -1,0 +1,47 @@
+package com.jungko.jungko_server.auth.oauth2.extractor;
+
+import java.util.Arrays;
+import java.util.Map;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+public class Oauth2AttributeHelper {
+
+
+	private final OAuth2User auth2User;
+
+	protected Oauth2AttributeHelper(OAuth2User auth2User) {
+		this.auth2User = auth2User;
+	}
+
+	public static Oauth2AttributeHelper of(OAuth2User auth2User) {
+		return new Oauth2AttributeHelper(auth2User);
+	}
+
+	public Map<String, Object> getAuthAttributes() {
+		return auth2User.getAttributes();
+	}
+
+	public <T> T getAttribute(String... name) {
+		return getMap(getAuthAttributes(), name);
+	}
+
+	public <T> T getAttribute(String name) {
+		return getMap(getAuthAttributes(), name);
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T> T getMap(Map<String, Object> map, String... names) {
+		if (names.length == 0) {
+			throw new IllegalArgumentException("names is empty");
+		}
+		try {
+			return names.length == 1 ?
+					(T) map.get(names[0])
+					: getMap((Map<String, Object>) map.get(names[0]),
+							Arrays.copyOfRange(names, 1, names.length));
+		} catch (Exception e) {
+			throw new IllegalArgumentException("names are invalid");
+		}
+
+	}
+}

--- a/src/main/java/com/jungko/jungko_server/card/controller/CardController.java
+++ b/src/main/java/com/jungko/jungko_server/card/controller/CardController.java
@@ -1,5 +1,8 @@
 package com.jungko.jungko_server.card.controller;
 
+import com.jungko.jungko_server.auth.annotation.LoginMemberInfo;
+import com.jungko.jungko_server.auth.domain.MemberRole;
+import com.jungko.jungko_server.auth.dto.MemberSessionDto;
 import com.jungko.jungko_server.card.dto.request.CardCreateRequestDto;
 import com.jungko.jungko_server.card.dto.request.CardUpdateRequestDto;
 import com.jungko.jungko_server.card.dto.response.CardListResponseDto;
@@ -15,6 +18,7 @@ import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -33,76 +37,91 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "카드", description = "카드 관련 API")
 public class CardController {
 
-    @Operation(summary = "카드 생성", description = "새 카드를 생성합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "created"),
-    })
-    @PostMapping(value = "/", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @ResponseStatus(HttpStatus.CREATED)
-    public void createCard(
-            @Valid @ModelAttribute CardCreateRequestDto dto) {
-        log.info("Called createCard dto: {}", dto);
-    }
+	@Operation(summary = "카드 생성", description = "새 카드를 생성합니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "201", description = "created"),
+	})
+	@PostMapping(value = "/", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@ResponseStatus(HttpStatus.CREATED)
+	@Secured(MemberRole.S_USER)
+	public void createCard(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
+			@Valid @ModelAttribute CardCreateRequestDto dto) {
+		log.info("Called createCard member: {}, dto: {}", memberSessionDto, dto);
+	}
 
-    @Operation(summary = "카드 삭제", description = "특정 카드를 삭제합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "no content"),
-    })
-    @DeleteMapping(value = "/{cardId}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteCard(
-            @PathVariable("cardId") Long cardId) {
-        log.info("Called deleteCard {}", cardId);
-    }
+	@Operation(summary = "카드 삭제", description = "특정 카드를 삭제합니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "204", description = "no content"),
+	})
+	@DeleteMapping(value = "/{cardId}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@Secured(MemberRole.S_USER)
+	public void deleteCard(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
+			@PathVariable("cardId") Long cardId) {
+		log.info("Called deleteCard member: {}, cardId: {}", memberSessionDto, cardId);
+	}
 
-    @Operation(summary = "카드 옵션 변경", description = "카드 옵션을 변경합니다. null이 아닌 값들만 변경합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "ok"),
-    })
-    @PatchMapping(value = "/{cardId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public void updateCard(
-            @Valid @ModelAttribute CardUpdateRequestDto dto,
-            @PathVariable("cardId") Long cardId) {
-        log.info("Called updateCard dto: {}, cardId: {}", dto, cardId);
-    }
+	@Operation(summary = "카드 옵션 변경", description = "카드 옵션을 변경합니다. null이 아닌 값들만 변경합니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "ok"),
+	})
+	@PatchMapping(value = "/{cardId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@Secured(MemberRole.S_USER)
+	public void updateCard(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
+			@Valid @ModelAttribute CardUpdateRequestDto dto,
+			@PathVariable("cardId") Long cardId) {
+		log.info("Called updateCard member: {}, dto: {}, cardId: {}", memberSessionDto, dto,
+				cardId);
+	}
 
-    @Operation(summary = "내 카드 목록 조회", description = "내가 만든 카드 목록을 조회합니다. 페이지네이션을 지원합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "ok"),
-    })
-    @GetMapping(value = "/members/me")
-    public CardListResponseDto getMyCards(
-            @RequestParam Integer page,
-            @RequestParam Integer size) {
-        log.info("Called getMyCards page: {}, size: {}", page, size);
+	@Operation(summary = "내 카드 목록 조회", description = "내가 만든 카드 목록을 조회합니다. 페이지네이션을 지원합니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "ok"),
+	})
+	@GetMapping(value = "/members/me")
+	@Secured(MemberRole.S_USER)
+	public CardListResponseDto getMyCards(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
+			@RequestParam Integer page,
+			@RequestParam Integer size) {
+		log.info("Called getMyCards member: {}, page: {}, size: {}", memberSessionDto, page, size);
 
-        return CardListResponseDto.builder().build();
-    }
+		return CardListResponseDto.builder().build();
+	}
 
-    @Operation(summary = "특정 유저 카드 목록 조회", description = "특정 유저가 만든 카드 목록을 조회합니다. 페이지네이션을 지원합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "ok"),
-    })
-    @GetMapping(value = "/members/{memberId}")
-    public CardListResponseDto getMemberCards(
-            @PathVariable("memberId") Long memberId,
-            @RequestParam Integer page,
-            @RequestParam Integer size) {
-        log.info("Called getMemberCards memberId: {}, page: {}, size: {}", memberId, page, size);
+	@Operation(summary = "특정 유저 카드 목록 조회", description = "특정 유저가 만든 카드 목록을 조회합니다. 페이지네이션을 지원합니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "ok"),
+	})
+	@GetMapping(value = "/members/{memberId}")
+	@Secured(MemberRole.S_USER)
+	public CardListResponseDto getMemberCards(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
+			@PathVariable("memberId") Long memberId,
+			@RequestParam Integer page,
+			@RequestParam Integer size) {
+		log.info("Called getMemberCards member: {}, memberId: {}, page: {}, size: {}",
+				memberSessionDto, memberId, page, size);
 
-        return CardListResponseDto.builder().build();
-    }
+		return CardListResponseDto.builder().build();
+	}
 
-    @Operation(summary = "인기 카드 목록 조회", description = "인기 카드 목록을 조회합니다. 페이지네이션을 지원합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "ok"),
-    })
-    @GetMapping(value = "/popular")
-    public CardListResponseDto getPopularCards(
-            @RequestParam Integer page,
-            @RequestParam Integer size) {
-        log.info("Called getPopularCards {}", page, size);
+	@Operation(summary = "인기 카드 목록 조회", description = "인기 카드 목록을 조회합니다. 페이지네이션을 지원합니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "ok"),
+	})
+	@GetMapping(value = "/popular")
+	@Secured(MemberRole.S_USER)
+	public CardListResponseDto getPopularCards(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
+			@RequestParam Integer page,
+			@RequestParam Integer size) {
+		log.info("Called getPopularCards member: {}, page: {}, size: {}", memberSessionDto, page,
+				size);
 
-        return CardListResponseDto.builder().build();
-    }
+		return CardListResponseDto.builder().build();
+	}
 }

--- a/src/main/java/com/jungko/jungko_server/card/controller/InterestedCardController.java
+++ b/src/main/java/com/jungko/jungko_server/card/controller/InterestedCardController.java
@@ -1,5 +1,8 @@
 package com.jungko.jungko_server.card.controller;
 
+import com.jungko.jungko_server.auth.annotation.LoginMemberInfo;
+import com.jungko.jungko_server.auth.domain.MemberRole;
+import com.jungko.jungko_server.auth.dto.MemberSessionDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -8,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -22,27 +26,31 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "관심 카드", description = "관심 카드 관련 API")
 public class InterestedCardController {
 
-  @Operation(summary = "관심 카드 등록", description = "특정 카드를 관심 카드로 등록합니다. 자신이 만든 카드는 등록할 수 없습니다. 이미 등록한 관심 카드를 재등록 시, 성공 응답을 주며 아무런 변화가 일어나지 않습니다.")
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "ok"),
-  })
-  @PutMapping(value = "/{cardId}/like")
-  @ResponseStatus(HttpStatus.OK)
-  public void likeCard(
-      @PathVariable("cardId") Long cardId) {
-    log.info("Called likeCard {}", cardId);
-  }
+	@Operation(summary = "관심 카드 등록", description = "특정 카드를 관심 카드로 등록합니다. 자신이 만든 카드는 등록할 수 없습니다. 이미 등록한 관심 카드를 재등록 시, 성공 응답을 주며 아무런 변화가 일어나지 않습니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "ok"),
+	})
+	@PutMapping(value = "/{cardId}/like")
+	@ResponseStatus(HttpStatus.OK)
+	@Secured(MemberRole.S_USER)
+	public void likeCard(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
+			@PathVariable("cardId") Long cardId) {
+		log.info("Called likeCard member: {}, cardId: {}", memberSessionDto, cardId);
+	}
 
-  @Operation(summary = "관심 카드 삭제", description = "특정 카드를 관심 카드에서 삭제합니다. 존재하지 않는 카드를 요청하면 404 실패 응답을 제공합니다.")
+	@Operation(summary = "관심 카드 삭제", description = "특정 카드를 관심 카드에서 삭제합니다. 존재하지 않는 카드를 요청하면 404 실패 응답을 제공합니다.")
 
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "204", description = "no content"),
-      @ApiResponse(responseCode = "404", description = "not found")
-  })
-  @DeleteMapping(value = "/{cardId}/like")
-  @ResponseStatus(HttpStatus.OK)
-  public void unlikeCard(
-      @PathVariable("cardId") Long cardId) {
-    log.info("Called unlikeCard {}", cardId);
-  }
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "204", description = "no content"),
+			@ApiResponse(responseCode = "404", description = "not found")
+	})
+	@DeleteMapping(value = "/{cardId}/like")
+	@ResponseStatus(HttpStatus.OK)
+	@Secured(MemberRole.S_USER)
+	public void unlikeCard(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
+			@PathVariable("cardId") Long cardId) {
+		log.info("Called unlikeCard member: {}, cardId: {}", memberSessionDto, cardId);
+	}
 }

--- a/src/main/java/com/jungko/jungko_server/config/ClientConfig.java
+++ b/src/main/java/com/jungko/jungko_server/config/ClientConfig.java
@@ -1,0 +1,16 @@
+package com.jungko.jungko_server.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+public class ClientConfig {
+
+	@Value("${jungko.client.url}")
+	private String clientUrl;
+
+	@Value("${jungko.client.callback}")
+	private String clientCallbackUrl;
+}

--- a/src/main/java/com/jungko/jungko_server/config/CookieConfig.java
+++ b/src/main/java/com/jungko/jungko_server/config/CookieConfig.java
@@ -1,0 +1,31 @@
+package com.jungko.jungko_server.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+public class CookieConfig {
+
+	@Value("${jungko.cookie.domain}")
+	private String domain;
+
+	@Value("${jungko.cookie.name}")
+	private String name;
+
+	@Value("${jungko.cookie.path}")
+	private String path;
+
+	@Value("${jungko.cookie.max-age}")
+	private int maxAge;
+
+	@Value("${jungko.cookie.http-only}")
+	private boolean httpOnly;
+
+	@Value("${jungko.cookie.secure}")
+	private boolean secure;
+
+	@Value("${jungko.cookie.same-site}")
+	private String sameSite;
+}

--- a/src/main/java/com/jungko/jungko_server/config/RestExceptionHandler.java
+++ b/src/main/java/com/jungko/jungko_server/config/RestExceptionHandler.java
@@ -3,6 +3,7 @@ package com.jungko.jungko_server.config;
 import com.jungko.jungko_server.util.NotFoundException;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -16,53 +17,53 @@ import org.springframework.web.server.ResponseStatusException;
 @RestControllerAdvice(annotations = RestController.class)
 public class RestExceptionHandler {
 
-    @ExceptionHandler(NotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleNotFound(final NotFoundException exception) {
-        final ErrorResponse errorResponse = new ErrorResponse();
-        errorResponse.setHttpStatus(HttpStatus.NOT_FOUND.value());
-        errorResponse.setException(exception.getClass().getSimpleName());
-        errorResponse.setMessage(exception.getMessage());
-        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
-    }
+	@ExceptionHandler(NotFoundException.class)
+	public ResponseEntity<ErrorResponse> handleNotFound(final NotFoundException exception) {
+		final ErrorResponse errorResponse = new ErrorResponse();
+		errorResponse.setHttpStatus(HttpStatus.NOT_FOUND.value());
+		errorResponse.setException(exception.getClass().getSimpleName());
+		errorResponse.setMessage(exception.getMessage());
+		return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+	}
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(
-            final MethodArgumentNotValidException exception) {
-        final BindingResult bindingResult = exception.getBindingResult();
-        final List<FieldError> fieldErrors = bindingResult.getFieldErrors()
-                .stream()
-                .map(error -> {
-                    final FieldError fieldError = new FieldError();
-                    fieldError.setErrorCode(error.getCode());
-                    fieldError.setField(error.getField());
-                    return fieldError;
-                })
-                .toList();
-        final ErrorResponse errorResponse = new ErrorResponse();
-        errorResponse.setHttpStatus(HttpStatus.BAD_REQUEST.value());
-        errorResponse.setException(exception.getClass().getSimpleName());
-        errorResponse.setFieldErrors(fieldErrors);
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
-    }
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(
+			final MethodArgumentNotValidException exception) {
+		final BindingResult bindingResult = exception.getBindingResult();
+		final List<FieldError> fieldErrors = bindingResult.getFieldErrors()
+				.stream()
+				.map(error -> {
+					final FieldError fieldError = new FieldError();
+					fieldError.setErrorCode(error.getCode());
+					fieldError.setField(error.getField());
+					return fieldError;
+				})
+				.collect(Collectors.toList());
+		final ErrorResponse errorResponse = new ErrorResponse();
+		errorResponse.setHttpStatus(HttpStatus.BAD_REQUEST.value());
+		errorResponse.setException(exception.getClass().getSimpleName());
+		errorResponse.setFieldErrors(fieldErrors);
+		return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+	}
 
-    @ExceptionHandler(ResponseStatusException.class)
-    public ResponseEntity<ErrorResponse> handleResponseStatus(
-            final ResponseStatusException exception) {
-        final ErrorResponse errorResponse = new ErrorResponse();
-        errorResponse.setHttpStatus(exception.getStatus().value());
-        errorResponse.setException(exception.getClass().getSimpleName());
-        errorResponse.setMessage(exception.getMessage());
-        return new ResponseEntity<>(errorResponse, exception.getStatus());
-    }
+	@ExceptionHandler(ResponseStatusException.class)
+	public ResponseEntity<ErrorResponse> handleResponseStatus(
+			final ResponseStatusException exception) {
+		final ErrorResponse errorResponse = new ErrorResponse();
+		errorResponse.setHttpStatus(exception.getStatus().value());
+		errorResponse.setException(exception.getClass().getSimpleName());
+		errorResponse.setMessage(exception.getMessage());
+		return new ResponseEntity<>(errorResponse, exception.getStatus());
+	}
 
-    @ExceptionHandler(Throwable.class)
-    @ApiResponse(responseCode = "4xx/5xx", description = "Error")
-    public ResponseEntity<ErrorResponse> handleThrowable(final Throwable exception) {
-        exception.printStackTrace();
-        final ErrorResponse errorResponse = new ErrorResponse();
-        errorResponse.setHttpStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
-        errorResponse.setException(exception.getClass().getSimpleName());
-        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
-    }
+	@ExceptionHandler(Throwable.class)
+	@ApiResponse(responseCode = "4xx/5xx", description = "Error")
+	public ResponseEntity<ErrorResponse> handleThrowable(final Throwable exception) {
+		exception.printStackTrace();
+		final ErrorResponse errorResponse = new ErrorResponse();
+		errorResponse.setHttpStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+		errorResponse.setException(exception.getClass().getSimpleName());
+		return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+	}
 
 }

--- a/src/main/java/com/jungko/jungko_server/config/SecurityConfig.java
+++ b/src/main/java/com/jungko/jungko_server/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.jungko.jungko_server.config;
 
+import com.jungko.jungko_server.auth.jwt.MemberSessionAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -7,6 +8,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationFilter;
 import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
@@ -33,9 +35,10 @@ public class SecurityConfig {
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
-		httpSecurity
 //		@formatter:off
+		httpSecurity
 				.formLogin().disable()
+				.addFilterAfter(new MemberSessionAuthenticationFilter(), BearerTokenAuthenticationFilter.class)
 				.cors()
 					.configurationSource(corsConfigurationSource())
 				.and()

--- a/src/main/java/com/jungko/jungko_server/config/SecurityConfig.java
+++ b/src/main/java/com/jungko/jungko_server/config/SecurityConfig.java
@@ -3,37 +3,80 @@ package com.jungko.jungko_server.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.authentication.configuration.EnableGlobalAuthentication;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
 
 @Configuration
-@RequiredArgsConstructor
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+	private final ServerConfig serverConfig;
+	private final ClientConfig clientConfig;
+	private final AuthenticationManager jwtAuthenticationManager;
+	private final AccessDeniedHandler jwtAccessDeniedHandler;
+	private final AuthenticationEntryPoint jwtAuthenticationEntryPoint;
+	private final AuthenticationSuccessHandler oauth2AuthenticationSuccessHandler;
+	private final AuthenticationFailureHandler oauth2AuthenticationFailureHandler;
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
-		return httpSecurity
-//				.cors()
-//				.configurationSource(corsConfigurationSource())
-//				.and()
+		httpSecurity
+//		@formatter:off
+				.formLogin().disable()
+				.cors()
+					.configurationSource(corsConfigurationSource())
+				.and()
 				.csrf().disable()
 				.sessionManagement()
-				.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+					.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 				.and()
-//				.oauth2ResourceServer()
-//				.bearerTokenResolver(new DefaultBearerTokenResolver())
-//				.jwt()
-//				.authenticationManager(jwtAuthenticationManager)
-//				.and()
-//				.accessDeniedHandler(jwtAccessDeniedHandler)
-//				.authenticationEntryPoint(jwtAuthenticationEntryPoint)
-//				.and()
-				.formLogin().disable()
-				.build();
+				.oauth2ResourceServer()
+					.bearerTokenResolver(new DefaultBearerTokenResolver())
+					.jwt()
+						.authenticationManager(jwtAuthenticationManager)
+					.and()
+					.accessDeniedHandler(jwtAccessDeniedHandler)
+					.authenticationEntryPoint(jwtAuthenticationEntryPoint)
+				.and()
+				.oauth2Login()
+					.successHandler(oauth2AuthenticationSuccessHandler)
+					.failureHandler(oauth2AuthenticationFailureHandler)
+					.userInfoEndpoint()
+					.and()
+					.authorizationEndpoint()
+						.baseUri(serverConfig.getOauth2LoginEndpoint())
+					.and()
+					.redirectionEndpoint()
+						.baseUri(serverConfig.getOauth2CallbackEndpoint())
+				;
+		return httpSecurity.build();
+//		@formatter:on
+	}
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+
+		configuration.addAllowedOrigin(clientConfig.getClientUrl());
+		configuration.addAllowedHeader("*");
+		configuration.addAllowedMethod("*");
+		configuration.setAllowCredentials(true);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
 	}
 }

--- a/src/main/java/com/jungko/jungko_server/config/ServerConfig.java
+++ b/src/main/java/com/jungko/jungko_server/config/ServerConfig.java
@@ -1,0 +1,16 @@
+package com.jungko.jungko_server.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+public class ServerConfig {
+
+	@Value("${jungko.server.oauth2.login-endpoint}")
+	private String oauth2LoginEndpoint;
+
+	@Value("${jungko.server.oauth2.callback-endpoint}")
+	private String oauth2CallbackEndpoint;
+}

--- a/src/main/java/com/jungko/jungko_server/keyword/controller/KeywordController.java
+++ b/src/main/java/com/jungko/jungko_server/keyword/controller/KeywordController.java
@@ -1,5 +1,8 @@
 package com.jungko.jungko_server.keyword.controller;
 
+import com.jungko.jungko_server.auth.annotation.LoginMemberInfo;
+import com.jungko.jungko_server.auth.domain.MemberRole;
+import com.jungko.jungko_server.auth.dto.MemberSessionDto;
 import com.jungko.jungko_server.keyword.dto.request.KeywordRequestDto;
 import com.jungko.jungko_server.keyword.dto.response.KeywordListResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -35,9 +39,11 @@ public class KeywordController {
 	})
 	@PutMapping(value = "/", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	@ResponseStatus(HttpStatus.CREATED)
+	@Secured(MemberRole.S_USER)
 	public void createKeyword(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
 			@Valid @ModelAttribute KeywordRequestDto dto) {
-		log.info("Called createKeyword {}", dto);
+		log.info("Called createKeyword member: {}, dto: {}", memberSessionDto, dto);
 	}
 
 	@Operation(summary = "키워드 삭제", description = "특정 키워드를 삭제합니다. 키워드 ID를 배열에 담아 ID에 해당하는 키워드들을 삭제합니다.")
@@ -47,9 +53,11 @@ public class KeywordController {
 	})
 	@DeleteMapping(value = "/{keywordId}")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@Secured(MemberRole.S_USER)
 	public void deleteCard(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
 			@PathVariable("keywordId") Long keywordId) {
-		log.info("Called deleteKeyword {}", keywordId);
+		log.info("Called deleteKeyword member: {}, keywordId: {}", memberSessionDto, keywordId);
 	}
 
 	@Operation(summary = "내가 등록한 키워드 목록 조회", description = "내가 등록한 키워드 목록을 조회합니다. 키워드 개수는 최대 50개로 제한됩니다.")
@@ -57,10 +65,13 @@ public class KeywordController {
 			@ApiResponse(responseCode = "200", description = "ok"),
 	})
 	@GetMapping(value = "/members/me")
+	@Secured(MemberRole.S_USER)
 	public KeywordListResponseDto getMyKeywords(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
 			@RequestParam Integer page,
 			@RequestParam Integer size) {
-		log.info("Called getMyKeywords page");
+		log.info("Called getMyKeywords member: {}, page: {}, size: {}", memberSessionDto, page,
+				size);
 
 		return KeywordListResponseDto.builder().build();
 	}
@@ -70,9 +81,11 @@ public class KeywordController {
 			@ApiResponse(responseCode = "200", description = "ok"),
 	})
 	@GetMapping(value = "/members/{memberId}")
-	public KeywordListResponseDto getMemberKeyowords(
+	@Secured(MemberRole.S_USER)
+	public KeywordListResponseDto getMemberKeywords(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
 			@PathVariable("memberId") Long memberId) {
-		log.info("Called getMemberKeywords memberId: {}", memberId);
+		log.info("Called getMemberKeywords member: {}, memberId: {}", memberSessionDto, memberId);
 
 		return KeywordListResponseDto.builder().build();
 	}

--- a/src/main/java/com/jungko/jungko_server/member/controller/MemberController.java
+++ b/src/main/java/com/jungko/jungko_server/member/controller/MemberController.java
@@ -1,5 +1,8 @@
 package com.jungko.jungko_server.member.controller;
 
+import com.jungko.jungko_server.auth.annotation.LoginMemberInfo;
+import com.jungko.jungko_server.auth.domain.MemberRole;
+import com.jungko.jungko_server.auth.dto.MemberSessionDto;
 import com.jungko.jungko_server.member.dto.request.MemberProfileUpdateRequestDto;
 import com.jungko.jungko_server.member.dto.response.MemberProfileResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import javax.validation.Valid;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -24,35 +28,42 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "회원", description = "회원 관련 API")
 public class MemberController {
 
-    @Operation(summary = "내 프로필 조회", description = "내 프로필을 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "ok"),
-    })
-    @GetMapping(value = "/me/profile")
-    public MemberProfileResponseDto getMyProfile() {
-        log.info("Called getMyProfile");
-        return MemberProfileResponseDto.builder().build();
-    }
+	@Operation(summary = "내 프로필 조회", description = "내 프로필을 조회합니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "ok"),
+	})
+	@GetMapping(value = "/me/profile")
+	@Secured(MemberRole.S_USER)
+	public MemberProfileResponseDto getMyProfile(
+			@LoginMemberInfo MemberSessionDto memberSessionDto
+	) {
+		log.info("Called getMyProfile member: {}", memberSessionDto);
+		return MemberProfileResponseDto.builder().build();
+	}
 
-    @Operation(summary = "내 프로필 수정", description = "내 프로필 정보를 수정합니다. null이 아닌 필드에 대해서만 수정이 이루어집니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "ok"),
-    })
-    @PatchMapping(value = "/me/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public void updateCard(
-            @Valid @ModelAttribute MemberProfileUpdateRequestDto dto,
-            @PathVariable("memberId") Long memberId) {
-        log.info("Called updateCard dto: {}", dto);
-    }
+	@Operation(summary = "내 프로필 수정", description = "내 프로필 정보를 수정합니다. null이 아닌 필드에 대해서만 수정이 이루어집니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "ok"),
+	})
+	@PatchMapping(value = "/me/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@Secured(MemberRole.S_USER)
+	public void updateCard(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
+			@Valid @ModelAttribute MemberProfileUpdateRequestDto dto
+	) {
+		log.info("Called updateCard member: {}, dto: {}", memberSessionDto, dto);
+	}
 
-    @Operation(summary = "회원 프로필 조회", description = "특정 회원의 프로필을 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "ok"),
-    })
-    @GetMapping(value = "/{memberId}/profile")
-    public MemberProfileResponseDto getMemberProfile(
-            @PathVariable("memberId") Long memberId) {
-        log.info("Called getMemberProfile memberId: {}", memberId);
-        return MemberProfileResponseDto.builder().build();
-    }
+	@Operation(summary = "회원 프로필 조회", description = "특정 회원의 프로필을 조회합니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "ok"),
+	})
+	@GetMapping(value = "/{memberId}/profile")
+	@Secured(MemberRole.S_USER)
+	public MemberProfileResponseDto getMemberProfile(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
+			@PathVariable("memberId") Long memberId) {
+		log.info("Called getMemberProfile member: {}, memberId: {}", memberSessionDto, memberId);
+		return MemberProfileResponseDto.builder().build();
+	}
 }

--- a/src/main/java/com/jungko/jungko_server/member/domain/Member.java
+++ b/src/main/java/com/jungko/jungko_server/member/domain/Member.java
@@ -1,11 +1,15 @@
 package com.jungko.jungko_server.member.domain;
 
+import com.jungko.jungko_server.auth.domain.Oauth2Type;
 import com.jungko.jungko_server.card.domain.Card;
 import com.jungko.jungko_server.card.domain.InterestedCard;
 import com.jungko.jungko_server.keyword.domain.InterestedKeyword;
 import com.jungko.jungko_server.notification.domain.Notification;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -24,45 +28,64 @@ import lombok.ToString;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
-    @Id
-    @Column(nullable = false, updatable = false)
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@Column(nullable = false, updatable = false)
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @Column(nullable = false, unique = true)
-    private String email;
+	@Column(nullable = false, unique = true)
+	private String email;
 
-    @Column
-    private String profileImageUrl;
+	@Column
+	private String profileImageUrl;
 
-    @Column(nullable = false, unique = true)
-    private String nickname;
+	@Column(nullable = false, unique = true)
+	private String nickname;
 
-    @Column(nullable = false)
-    private boolean notificationAgreement;
+	@Column(nullable = false)
+	private boolean notificationAgreement;
 
-    @Column(nullable = false)
-    private String oauthType;
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private Oauth2Type oauthType;
 
-    @Column(nullable = false)
-    private String oauthId;
+	@Column(nullable = false)
+	private String oauthId;
 
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
+	@Column(nullable = false)
+	private LocalDateTime createdAt;
 
-    @Column
-    private LocalDateTime deletedAt;
+	@Column
+	private LocalDateTime deletedAt;
 
-    @OneToMany(mappedBy = "member")
-    private Set<Notification> notifications;
+	@ToString.Exclude
+	@OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
+	private Set<Notification> notifications;
 
-    @OneToMany(mappedBy = "member")
-    private Set<InterestedCard> interestedCards;
+	@ToString.Exclude
+	@OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
+	private Set<InterestedCard> interestedCards;
 
-    @OneToMany(mappedBy = "member")
-    private Set<Card> cards;
+	@ToString.Exclude
+	@OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
+	private Set<Card> cards;
 
-    @OneToMany(mappedBy = "member")
-    private Set<InterestedKeyword> interestedKeywords;
+	@ToString.Exclude
+	@OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
+	private Set<InterestedKeyword> interestedKeywords;
 
+	public static Member createMember(String email, String profileImageUrl, String nickname,
+			boolean notificationAgreement, Oauth2Type oauth2Type, String oauthId,
+			LocalDateTime now) {
+		Member member = new Member();
+		member.email = email;
+		member.profileImageUrl = profileImageUrl;
+		member.nickname = nickname;
+		member.notificationAgreement = notificationAgreement;
+		member.oauthType = oauth2Type;
+		System.out.println("oauthType = " + oauth2Type);
+		member.oauthId = oauthId;
+		member.createdAt = now;
+		return member;
+	}
 }

--- a/src/main/java/com/jungko/jungko_server/member/domain/Member.java
+++ b/src/main/java/com/jungko/jungko_server/member/domain/Member.java
@@ -39,7 +39,7 @@ public class Member {
 	@Column
 	private String profileImageUrl;
 
-	@Column(nullable = false, unique = true)
+	@Column(nullable = false)
 	private String nickname;
 
 	@Column(nullable = false)
@@ -83,7 +83,6 @@ public class Member {
 		member.nickname = nickname;
 		member.notificationAgreement = notificationAgreement;
 		member.oauthType = oauth2Type;
-		System.out.println("oauthType = " + oauth2Type);
 		member.oauthId = oauthId;
 		member.createdAt = now;
 		return member;

--- a/src/main/java/com/jungko/jungko_server/member/infrastructure/MemberRepository.java
+++ b/src/main/java/com/jungko/jungko_server/member/infrastructure/MemberRepository.java
@@ -1,13 +1,12 @@
 package com.jungko.jungko_server.member.infrastructure;
 
 import com.jungko.jungko_server.member.domain.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    boolean existsByEmailIgnoreCase(String email);
 
-    boolean existsByNicknameIgnoreCase(String nickname);
-
+	Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/jungko/jungko_server/notification/controller/NotificationController.java
+++ b/src/main/java/com/jungko/jungko_server/notification/controller/NotificationController.java
@@ -1,8 +1,12 @@
 package com.jungko.jungko_server.notification.controller;
 
+import com.jungko.jungko_server.auth.annotation.LoginMemberInfo;
+import com.jungko.jungko_server.auth.domain.MemberRole;
+import com.jungko.jungko_server.auth.dto.MemberSessionDto;
 import com.jungko.jungko_server.notification.dto.response.CardNoticeListResponseDto;
 import com.jungko.jungko_server.notification.dto.response.KeywordNoticeListResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,97 +32,118 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @Tag(name = "알림", description = "알림 관련 API")
 public class NotificationController {
 
-        @Operation(summary = "전체 카드 알림 조회", description = "전체 카드 알림을 조회합니다. 페이지네이션을 지원합니다. 알림은 최근 2주일까지만 제공됩니다.")
-        @ApiResponses(value = {
-                        @ApiResponse(responseCode = "200", description = "ok"),
-                        @ApiResponse(responseCode = "500", description = "internal server error")
-        })
-        @GetMapping(value = "/cards")
-        public CardNoticeListResponseDto getCardNotice(
-                        @RequestParam Integer page,
-                        @RequestParam Integer size) {
-                log.info("Called getCardNotice page: {}, size: {}", page, size);
+	@Operation(summary = "전체 카드 알림 조회", description = "전체 카드 알림을 조회합니다. 페이지네이션을 지원합니다. 알림은 최근 2주일까지만 제공됩니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "ok"),
+			@ApiResponse(responseCode = "500", description = "internal server error")
+	})
+	@GetMapping(value = "/cards")
+	@Secured(MemberRole.S_USER)
+	public CardNoticeListResponseDto getCardNotice(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
+			@RequestParam Integer page,
+			@RequestParam Integer size) {
+		log.info("Called getCardNotice member: {}, page: {}, size: {}", memberSessionDto, page,
+				size);
 
-                return CardNoticeListResponseDto.builder().build();
-        }
+		return CardNoticeListResponseDto.builder().build();
+	}
 
-        @Operation(summary = "전체 키워드 알림 조회", description = "전체 키워드 알림을 조회합니다. 페이지네이션을 지원합니다. 알림은 최근 2주일까지만 제공됩니다.")
-        @ApiResponses(value = {
-                        @ApiResponse(responseCode = "200", description = "ok"),
-                        @ApiResponse(responseCode = "500", description = "internal server error")
-        })
-        @GetMapping(value = "/keywords")
-        public KeywordNoticeListResponseDto getKeywordNotice(
-                        @RequestParam Integer page,
-                        @RequestParam Integer size) {
-                log.info("Called getKeywordNotice page: {}, size: {}", page, size);
+	@Operation(summary = "전체 키워드 알림 조회", description = "전체 키워드 알림을 조회합니다. 페이지네이션을 지원합니다. 알림은 최근 2주일까지만 제공됩니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "ok"),
+			@ApiResponse(responseCode = "500", description = "internal server error")
+	})
+	@GetMapping(value = "/keywords")
+	@Secured(MemberRole.S_USER)
+	public KeywordNoticeListResponseDto getKeywordNotice(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
+			@RequestParam Integer page,
+			@RequestParam Integer size) {
+		log.info("Called getKeywordNotice member: {}, page: {}, size: {}", memberSessionDto, page,
+				size);
 
-                return KeywordNoticeListResponseDto.builder().build();
-        }
+		return KeywordNoticeListResponseDto.builder().build();
+	}
 
-        @Operation(summary = "전체 카드 알림 삭제", description = "전체 카드 알림을 삭제합니다.")
-        @ApiResponses(value = {
-                        @ApiResponse(responseCode = "204", description = "no content"),
-                        @ApiResponse(responseCode = "500", description = "internal server error")
-        })
-        @DeleteMapping(value = "/cards")
-        @ResponseStatus(HttpStatus.NO_CONTENT)
-        public void deleteCardNotice() {
-                log.info("Called deleteNotice");
-        }
+	@Operation(summary = "전체 카드 알림 삭제", description = "전체 카드 알림을 삭제합니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "204", description = "no content"),
+			@ApiResponse(responseCode = "500", description = "internal server error")
+	})
+	@DeleteMapping(value = "/cards")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@Secured(MemberRole.S_USER)
+	public void deleteCardNotice(
+			@LoginMemberInfo MemberSessionDto memberSessionDto
+	) {
+		log.info("Called deleteNotice member: {}", memberSessionDto);
+	}
 
-        @Operation(summary = "전체 키워드 알림 삭제", description = "전체 키워드 알림을 삭제합니다.")
-        @ApiResponses(value = {
-                        @ApiResponse(responseCode = "204", description = "no content"),
-                        @ApiResponse(responseCode = "500", description = "internal server error")
-        })
-        @DeleteMapping(value = "/keywords")
-        @ResponseStatus(HttpStatus.NO_CONTENT)
-        public void deleteKeywordNotice() {
-                log.info("Called deleteNotice");
-        }
+	@Operation(summary = "전체 키워드 알림 삭제", description = "전체 키워드 알림을 삭제합니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "204", description = "no content"),
+			@ApiResponse(responseCode = "500", description = "internal server error")
+	})
+	@DeleteMapping(value = "/keywords")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@Secured(MemberRole.S_USER)
+	public void deleteKeywordNotice(
+			@LoginMemberInfo MemberSessionDto memberSessionDto
+	) {
+		log.info("Called deleteNotice member: {}", memberSessionDto);
+	}
 
-        @Operation(summary = "특정 알림 삭제", description = "특정 알림을 삭제합니다. 알림 ID를 배열에 담아 ID에 해당하는 알림들을 삭제합니다.")
-        @ApiResponses(value = {
-                        @ApiResponse(responseCode = "204", description = "no content"),
-                        @ApiResponse(responseCode = "500", description = "internal server error")
-        })
-        @DeleteMapping(value = "/")
-        @ResponseStatus(HttpStatus.NO_CONTENT)
-        public void deleteNotice(
-                        @Valid @ModelAttribute List<Long> noticeIds) {
-                log.info("Called deleteNotice noticeIds: {}", noticeIds);
-        }
+	@Operation(summary = "특정 알림 삭제", description = "특정 알림을 삭제합니다. 알림 ID를 배열에 담아 ID에 해당하는 알림들을 삭제합니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "204", description = "no content"),
+			@ApiResponse(responseCode = "500", description = "internal server error")
+	})
+	@DeleteMapping(value = "/")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@Secured(MemberRole.S_USER)
+	public void deleteNotice(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
+			@Valid @ModelAttribute List<Long> noticeIds) {
+		log.info("Called deleteNotice member: {}, noticeIds: {}", memberSessionDto, noticeIds);
+	}
 
-        @Operation(summary = "특정 카드 알림 ON/OFF", description = "특정 카드에 대해 알림을 ON/OFF 합니다. 토글 API입니다.")
-        @ApiResponses(value = {
-                        @ApiResponse(responseCode = "200", description = "ok"),
-                        @ApiResponse(responseCode = "500", description = "internal server error")
-        })
-        @PutMapping(value = "/cards/{cardId}")
-        public void cardNoticeToggle(
-                        @PathVariable("cardId") Long cardId) {
-                log.info("Called cardNoticeToggle cardId: {}", cardId);
-        }
+	@Operation(summary = "특정 카드 알림 ON/OFF", description = "특정 카드에 대해 알림을 ON/OFF 합니다. 토글 API입니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "ok"),
+			@ApiResponse(responseCode = "500", description = "internal server error")
+	})
+	@PutMapping(value = "/cards/{cardId}")
+	@Secured(MemberRole.S_USER)
+	public void cardNoticeToggle(
+			@PathVariable("cardId") Long cardId) {
+		log.info("Called cardNoticeToggle cardId: {}", cardId);
+	}
 
-        @Operation(summary = "특정 키워드 알림 ON/OFF", description = "특정 키워드에 대한 알림을 ON/OFF 합니다. 토글 API입니다.")
-        @ApiResponses(value = {
-                        @ApiResponse(responseCode = "200", description = "ok"),
-                        @ApiResponse(responseCode = "500", description = "internal server error")
-        })
-        @PutMapping(value = "/keywords/{keywordId}")
-        public void keywordNoticeToggle(
-                        @PathVariable("keywordId") Long keywordId) {
-                log.info("Called keywordNoticeToggle keywordId: {}", keywordId);
-        }
+	@Operation(summary = "특정 키워드 알림 ON/OFF", description = "특정 키워드에 대한 알림을 ON/OFF 합니다. 토글 API입니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "ok"),
+			@ApiResponse(responseCode = "500", description = "internal server error")
+	})
+	@PutMapping(value = "/keywords/{keywordId}")
+	@Secured(MemberRole.S_USER)
+	public void keywordNoticeToggle(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
+			@PathVariable("keywordId") Long keywordId) {
+		log.info("Called keywordNoticeToggle member: {}, keywordId: {}", memberSessionDto,
+				keywordId);
+	}
 
-        @Operation(summary = "전체 알림 ON/OFF", description = "회원의 전체 알림 설정을 조작합니다. memberId를 통해 해당 member의 notification_agreement의 bool값을 변경합니다")
-        @ApiResponses(value = {
-                        @ApiResponse(responseCode = "200", description = "ok"),
-                        @ApiResponse(responseCode = "500", description = "internal server error")
-        })
-        @PutMapping(value = "/setting")
-        public void totalNoticeToggle() {
-                log.info("Called totalNoticeToggle");
-        }
+	@Operation(summary = "전체 알림 ON/OFF", description = "회원의 전체 알림 설정을 조작합니다. memberId를 통해 해당 member의 notification_agreement의 bool값을 변경합니다")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "ok"),
+			@ApiResponse(responseCode = "500", description = "internal server error")
+	})
+	@PutMapping(value = "/setting")
+	@Secured(MemberRole.S_USER)
+	public void totalNoticeToggle(
+			@LoginMemberInfo MemberSessionDto memberSessionDto
+	) {
+		log.info("Called totalNoticeToggle member: {}", memberSessionDto);
+	}
 }

--- a/src/main/java/com/jungko/jungko_server/product/controller/ProductController.java
+++ b/src/main/java/com/jungko/jungko_server/product/controller/ProductController.java
@@ -1,6 +1,9 @@
 package com.jungko.jungko_server.product.controller;
 
 import com.jungko.jungko_server.area.dto.response.AreaListResponseDto;
+import com.jungko.jungko_server.auth.annotation.LoginMemberInfo;
+import com.jungko.jungko_server.auth.domain.MemberRole;
+import com.jungko.jungko_server.auth.dto.MemberSessionDto;
 import com.jungko.jungko_server.product.dto.response.ProductCategoryListResponseDto;
 import com.jungko.jungko_server.product.dto.response.ProductDetailResponseDto;
 import com.jungko.jungko_server.product.dto.response.ProductListResponseDto;
@@ -12,6 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,76 +30,94 @@ import org.springframework.data.domain.Sort.Order;
 @Tag(name = "상품", description = "상품 관련 API")
 public class ProductController {
 
-        @Operation(summary = "검색어를 통해 상품 목록을 조회", description = "상세 검색 페이지, 제목과 카테고리, 지역, 가격범위를 기반으로하여 상품을 조회합니다. 제목과 일치하는 결과를 제공합니다.")
-        @ApiResponses(value = {
-                        @ApiResponse(responseCode = "200", description = "ok"),
-        })
-        @GetMapping(value = "/search")
-        public ProductListResponseDto searchProducts(
-                        @RequestParam String query,
-                        @RequestParam Integer page,
-                        @RequestParam Integer size,
-                        @RequestParam String sort,
-                        @RequestParam Order order) {
-                log.info("Called searchProducts query: {}, page: {}, size: {}, sort: {}, order{}", query, page, size,
-                                sort,
-                                order);
-                return ProductListResponseDto.builder().build();
-        }
+	@Operation(summary = "검색어를 통해 상품 목록을 조회", description = "상세 검색 페이지, 제목과 카테고리, 지역, 가격범위를 기반으로하여 상품을 조회합니다. 제목과 일치하는 결과를 제공합니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "ok"),
+	})
+	@GetMapping(value = "/search")
+	@Secured(MemberRole.S_USER)
+	public ProductListResponseDto searchProducts(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
+			@RequestParam String query,
+			@RequestParam Integer page,
+			@RequestParam Integer size,
+			@RequestParam String sort,
+			@RequestParam Order order) {
+		log.info(
+				"Called searchProducts member: {}, query: {}, page: {}, size: {}, sort: {}, order: {}",
+				memberSessionDto, query,
+				page, size,
+				sort,
+				order);
+		return ProductListResponseDto.builder().build();
+	}
 
-        @Operation(summary = "검색 결과에 대한 연관 검색어 조회", description = "현재 검색 결과의 연관 검색어를 제공합니다.")
-        @ApiResponses(value = {
-                        @ApiResponse(responseCode = "200", description = "ok"),
-        })
-        @GetMapping(value = "/search/related")
-        public RelatedQueryListResponseDto searchByRelatedKeyword(
-                        @RequestParam String query) {
-                log.info("Called searchByRelatedKeyword query: {}", query);
-                return RelatedQueryListResponseDto.builder().build();
-        }
+	@Operation(summary = "검색 결과에 대한 연관 검색어 조회", description = "현재 검색 결과의 연관 검색어를 제공합니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "ok"),
+	})
+	@GetMapping(value = "/search/related")
+	@Secured(MemberRole.S_USER)
+	public RelatedQueryListResponseDto searchByRelatedKeyword(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
+			@RequestParam String query) {
+		log.info("Called searchByRelatedKeyword member: {}, query: {}", memberSessionDto, query);
+		return RelatedQueryListResponseDto.builder().build();
+	}
 
-        @Operation(summary = "선택한 상품들 비교", description = "선택한 상품들을 비교합니다.")
-        @ApiResponses(value = {
-                        @ApiResponse(responseCode = "200", description = "ok"),
-        })
-        @GetMapping(value = "/compare")
-        public ProductListResponseDto compareProducts(
-                        @RequestParam Integer page,
-                        @RequestParam Integer size,
-                        @RequestParam String sort,
-                        @RequestParam Order order) {
-                log.info("Called compareProducts page: {}, size: {}, sort: {}, order: {}", page, size, sort, order);
-                return ProductListResponseDto.builder().build();
-        }
+	@Operation(summary = "선택한 상품들 비교", description = "선택한 상품들을 비교합니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "ok"),
+	})
+	@GetMapping(value = "/compare")
+	@Secured(MemberRole.S_USER)
+	public ProductListResponseDto compareProducts(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
+			@RequestParam Integer page,
+			@RequestParam Integer size,
+			@RequestParam String sort,
+			@RequestParam Order order) {
+		log.info("Called compareProducts member: {}, page: {}, size: {}, sort: {}, order: {}",
+				memberSessionDto, page, size, sort, order);
+		return ProductListResponseDto.builder().build();
+	}
 
-        @Operation(summary = "특정 상품 상세 정보 조회", description = "특정 상품의 상세 정보를 조회합니다.")
-        @ApiResponses(value = {
-                        @ApiResponse(responseCode = "200", description = "ok"),
-        })
-        @GetMapping(value = "/{productId}")
-        public ProductDetailResponseDto getProductDetail(
-                        @PathVariable("productId") Long productId) {
-                log.info("Called getProductDetail productId: {}", productId);
-                return ProductDetailResponseDto.builder().build();
-        }
+	@Operation(summary = "특정 상품 상세 정보 조회", description = "특정 상품의 상세 정보를 조회합니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "ok"),
+	})
+	@GetMapping(value = "/{productId}")
+	@Secured(MemberRole.S_USER)
+	public ProductDetailResponseDto getProductDetail(
+			@LoginMemberInfo MemberSessionDto memberSessionDto,
+			@PathVariable("productId") Long productId) {
+		log.info("Called getProductDetail member: {}, productId: {}", memberSessionDto, productId);
+		return ProductDetailResponseDto.builder().build();
+	}
 
-        @Operation(summary = "전체 카테고리 목록 조회", description = "전체 카테고리 목록을 조회합니다. 리소스 수가 많지 않으므로 페이지네이션을 지원하지 않습니다.")
-        @ApiResponses(value = {
-                        @ApiResponse(responseCode = "200", description = "ok"),
-        })
-        @GetMapping(value = "/categories")
-        public ProductCategoryListResponseDto getAllCategories() {
-                log.info("Called getAllCategories");
-                return ProductCategoryListResponseDto.builder().build();
-        }
+	@Operation(summary = "전체 카테고리 목록 조회", description = "전체 카테고리 목록을 조회합니다. 리소스 수가 많지 않으므로 페이지네이션을 지원하지 않습니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "ok"),
+	})
+	@GetMapping(value = "/categories")
+	@Secured(MemberRole.S_USER)
+	public ProductCategoryListResponseDto getAllCategories(
+			@LoginMemberInfo MemberSessionDto memberSessionDto
+	) {
+		log.info("Called getAllCategories member: {}", memberSessionDto);
+		return ProductCategoryListResponseDto.builder().build();
+	}
 
-        @Operation(summary = "전체 지역 목록 조회", description = "전체 지역 목록을 조회합니다. 리소스 수가 많지 않으므로 페이지네이션을 지원하지 않습니다.")
-        @ApiResponses(value = {
-                        @ApiResponse(responseCode = "200", description = "ok"),
-        })
-        @GetMapping(value = "/areas")
-        public AreaListResponseDto getAllAreas() {
-                log.info("Called getAllAreas");
-                return AreaListResponseDto.builder().build();
-        }
+	@Operation(summary = "전체 지역 목록 조회", description = "전체 지역 목록을 조회합니다. 리소스 수가 많지 않으므로 페이지네이션을 지원하지 않습니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "ok"),
+	})
+	@GetMapping(value = "/areas")
+	@Secured(MemberRole.S_USER)
+	public AreaListResponseDto getAllAreas(
+			@LoginMemberInfo MemberSessionDto memberSessionDto
+	) {
+		log.info("Called getAllAreas member: {}", memberSessionDto);
+		return AreaListResponseDto.builder().build();
+	}
 }

--- a/src/main/java/com/jungko/jungko_server/util/AuthResponseMessages.java
+++ b/src/main/java/com/jungko/jungko_server/util/AuthResponseMessages.java
@@ -1,0 +1,8 @@
+package com.jungko.jungko_server.util;
+
+public abstract class AuthResponseMessages {
+	public final static String OAUTH2_FAILURE = "OAuth2 인증에 실패했습니다.";
+	public final static String JWT_ACCESS_FAILURE = "해당 토큰으로 접근할 수 없습니다.";
+	public final static String JWT_AUTH_FAILURE = "해당 토큰이 인증되지 않았습니다.";
+}
+

--- a/src/main/java/com/jungko/jungko_server/util/JwtAuthenticationTokenException.java
+++ b/src/main/java/com/jungko/jungko_server/util/JwtAuthenticationTokenException.java
@@ -1,0 +1,8 @@
+package com.jungko.jungko_server.util;
+
+public class JwtAuthenticationTokenException extends RuntimeException {
+
+	public JwtAuthenticationTokenException(String s) {
+		super(s);
+	}
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 작업 ID를 적어주세요. 예) TSK-55

소셜 로그인 기능을 추가했습니다.
논의했던대로 네이버, 카카오, 구글 로그인을 구현했습니다.
스프링 부트 3.x.x 대의 시큐리티가 레퍼런스가 별로 없어서, 2.7.10로 낮추어 진행했습니다. 
개발 기간 단축을 위해 닉네임 unique key를 제거했습니다.

### 동작 흐름
/api/v1/auth/login/oauth-types/{소셜 로그인 타입} 엔드포인트로 접근하면 소셜 기관 로그인 페이지로 이동합니다.
여기서 로그인을 마치면 /api/v1/auth/login/callback/oauth-types/{소셜 로그인 타입} 엔드포인트로 리다이렉션 됩니다.
authorization_code와 token의 교환과 유저 정보 요청의 과정은 security 내부에서 진행됩니다.
스프링이 `authentication` 객체 안에 인증 정보를 담게 되고, 여기 안에 들어있는 인증 정보를 우리 서버 상황에 맞도록 adapt하여 DB에 저장합니다.
이후 memberId 정보를 JWT 토큰에 포함시킨 상태로 인코딩하고, 토큰 정보를 브라우저 쿠키에 담아 미리 약속한 클라이언트 콜백 주소(임의로 `/home`으로 지정했으나 추후 논의 필요)로 리다이렉션시킵니다.